### PR TITLE
libdns/netcup: Bump libdns version to v0.2.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/libdns/netcup
 
 go 1.17
 
-require github.com/libdns/libdns v0.2.1
+require github.com/libdns/libdns v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/libdns/libdns v0.2.1 h1:Wu59T7wSHRgtA0cfxC+n1c/e+O3upJGWytknkmFEDis=
-github.com/libdns/libdns v0.2.1/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
+github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
+github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/util.go
+++ b/util.go
@@ -24,7 +24,7 @@ func toLibdnsRecords(netcupRecords []dnsRecord, ttl int64) []libdns.Record {
 			Name:     record.HostName,
 			Value:    record.Destination,
 			TTL:      time.Duration(ttl * int64(time.Second)),
-			Priority: uint(record.Priority), // Convert int to uint to fix build errors with libdns v0.2.2
+			Priority: uint(record.Priority),
 		}
 		libdnsRecords = append(libdnsRecords, libdnsRecord)
 	}
@@ -40,7 +40,7 @@ func toNetcupRecords(libnsRecords []libdns.Record) []dnsRecord {
 			HostName:    record.Name,
 			RecType:     record.Type,
 			Destination: record.Value,
-			Priority:    int(record.Priority), // Convert uint to int to fix build errors with libdns v0.2.2
+			Priority:    int(record.Priority),
 		}
 		netcupRecords = append(netcupRecords, netcupRecord)
 	}

--- a/util.go
+++ b/util.go
@@ -24,7 +24,7 @@ func toLibdnsRecords(netcupRecords []dnsRecord, ttl int64) []libdns.Record {
 			Name:     record.HostName,
 			Value:    record.Destination,
 			TTL:      time.Duration(ttl * int64(time.Second)),
-			Priority: record.Priority,
+			Priority: uint(record.Priority), // Convert int to uint to fix build errors with libdns v0.2.2
 		}
 		libdnsRecords = append(libdnsRecords, libdnsRecord)
 	}
@@ -40,7 +40,7 @@ func toNetcupRecords(libnsRecords []libdns.Record) []dnsRecord {
 			HostName:    record.Name,
 			RecType:     record.Type,
 			Destination: record.Value,
-			Priority:    record.Priority,
+			Priority:    int(record.Priority), // Convert uint to int to fix build errors with libdns v0.2.2
 		}
 		netcupRecords = append(netcupRecords, netcupRecord)
 	}


### PR DESCRIPTION
libdns/netcup: Bump libdns version to v0.2.2

I am building this plugin together with cloudflare. Since cloudflare does an indirect upgrade of the libdns version, the build fails.

This PR fixes the build as single module, or together with cloudflare.