### PR TITLE
libdns/netcup: Upgrade and adapt to libdns v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,6 @@ func main() {
 
 **:warning: The netcup API does not offer setting the TTL for individual records.**
 
-Updating and deleting records can be done by either filling all struct fields of the dnsRecord, including the ID, or just Name and Type (+ Priority for MX records). Then the first record matching these criteria is updated/deleted.
+**:warning: As the ID attribute has been removed in the libdns record structs, using the ID field is not possible.**
+
+Updating and deleting records can be done by either filling all struct fields of the dnsRecord, or just Name and Type (+ Priority for MX records). Then the first record matching these criteria is updated/deleted.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/libdns/netcup
 
 go 1.17
 
-require github.com/libdns/libdns v0.2.2
+require github.com/libdns/libdns v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
-github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/libdns/libdns v1.0.0 h1:IvYaz07JNz6jUQ4h/fv2R4sVnRnm77J/aOuC9B+TQTA=
+github.com/libdns/libdns v1.0.0/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/provider.go
+++ b/provider.go
@@ -50,7 +50,7 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 		return nil, err
 	}
 
-	return toLibdnsRecords(recordSet.DnsRecords, dnsZone.TTL), nil
+	return toLibdnsRecords(recordSet.DnsRecords, dnsZone.TTL)
 }
 
 // AppendRecords adds records to the zone. It returns the records that were added.
@@ -99,7 +99,7 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 	// the netcup API always returns all records, so the ones before the update have to be compared to the ones after to return only the appended records
 	appendedRecords := difference(updatedRecordSet.DnsRecords, existingRecordSet.DnsRecords)
 
-	return toLibdnsRecords(appendedRecords, dnsZone.TTL), nil
+	return toLibdnsRecords(appendedRecords, dnsZone.TTL)
 }
 
 // SetRecords sets the records in the zone, either by updating existing records or creating new ones.
@@ -150,7 +150,7 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 	// the netcup API always returns all records, so the ones before the update have to be compared to the ones after to return only the updated records
 	updatedRecords := difference(updatedRecordSet.DnsRecords, existingRecordSet.DnsRecords)
 
-	return toLibdnsRecords(updatedRecords, dnsZone.TTL), nil
+	return toLibdnsRecords(updatedRecords, dnsZone.TTL)
 }
 
 // DeleteRecords deletes the records from the zone. It returns the records that were deleted.
@@ -198,7 +198,7 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 	// the netcup API always returns all records, so the ones before the deletion have to be compared to the ones after to return only the deleted records
 	deletedRecords := difference(existingRecordSet.DnsRecords, updatedRecordSet.DnsRecords)
 
-	return toLibdnsRecords(deletedRecords, dnsZone.TTL), nil
+	return toLibdnsRecords(deletedRecords, dnsZone.TTL)
 }
 
 // Interface guards

--- a/provider_test.go
+++ b/provider_test.go
@@ -17,10 +17,9 @@ var (
 	apiPassword    = ""
 	zone           = ""
 	testRecords    = []libdns.Record{
-		libdns.RR{
-			Type: "TXT",
+		libdns.TXT{
 			Name: "test",
-			Data: "testval1",
+			Text: "testval1",
 		},
 	}
 )


### PR DESCRIPTION
Since the release of libdns `v1.0.0`, caddy also upgraded in their version `v2.10.0` to the new stable release of libdns. This caused the caddy-dns package for netcup to break, as mentioned in https://github.com/caddy-dns/netcup/issues/9 .

I've updated the libdns package to `v1.0.0` and made the required changes to pass the Tests. Slight modifications to the tests were required but should result in the same behavior. 

The main concern is the missing ID field in the new libdns Record Structs, which requires the library to choose the first found record to be chosen. However, this was already implemented before this change and should work as expected.

> As this is my first work with the `libdns` library, feel free to do a thorough review of my changes. 

Fixes #2 